### PR TITLE
CMake: add support of MSYS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cardlock)
 
 find_package(Threads REQUIRED)
 
-if(WIN32)
+if(WIN32 OR MSYS)
     add_library(PkgConfig::PCSCLITE INTERFACE IMPORTED)
     target_link_libraries(PkgConfig::PCSCLITE INTERFACE winscard)
 elseif(APPLE)
@@ -15,6 +15,10 @@ elseif(APPLE)
 else()
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(PCSCLITE libpcsclite REQUIRED IMPORTED_TARGET)
+endif()
+
+if(MSYS)
+	add_compile_options(-mwin32)
 endif()
 
 add_executable(cardlock cardlock.c)


### PR DESCRIPTION
We need to check for MSYS othewise cmaks will use the "else"
configuration that is for GNU/Linux

We also need to use the compiler option "-mwin32" so that _WIN32 is
defined.