### PR TITLE
Do not release the PC/SC before the thread finishes

### DIFF
--- a/cardlock_cancel.c
+++ b/cardlock_cancel.c
@@ -90,7 +90,6 @@ int main(int argc, char **argv)
 #endif
     fprintf(stderr, "cancelling\n");
     CHECK(SCardCancel(context));
-    CHECK(SCardReleaseContext(context));
     fprintf(stderr, "done\n");
 
 #ifdef _WIN32
@@ -99,6 +98,8 @@ int main(int argc, char **argv)
 #else
     pthread_join(thread, NULL);
 #endif
+
+    CHECK(SCardReleaseContext(context));
 
     return 0;
 }


### PR DESCRIPTION
The problem was that SCardConnect() in the thread was interrupted NOT by
SCardCancel() but because the PC/SC context was destroyed too early.